### PR TITLE
add Super-Linter action

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,29 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: Lint Code Base
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **⚠️ Note:** This is a working document that will certainly be changed a lot :)
 
 [![Discord](https://img.shields.io/discord/971137288471998574?logo=discord)](https://discord.gg/nBFmWqZT9V)
+[![GitHub Super-Linter](https://github.com/bruno-robot/bruno-robot/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/bruno-robot/bruno-robot/actions/workflows/super-linter.yml)
 
 TLDR: Starting out with soccer playing robots is too complicated.
 


### PR DESCRIPTION
I hereby suggest to use a linter. This will give us a more consistent code base.
The advantage of the Super-Linter is that it supports many different languages, no matter if we use C / C++ / Rust or whatever, or just want to unify our Markdown documentation :)